### PR TITLE
open study mushrooms in new tab

### DIFF
--- a/pages/components/PostMortem.tsx
+++ b/pages/components/PostMortem.tsx
@@ -45,6 +45,7 @@ export const PostMortem = ({ trainingData }: PostMortemProps) => {
                 brandColor={brandColors.blueGrey}
                 href={`/bank/${misidentifiedMushroom}`}
                 styles={{ size: "xs" }}
+                openLinkInNewTab
               >
                 Study
               </CustomBtn>

--- a/server/routers/test/trpc.test.ts
+++ b/server/routers/test/trpc.test.ts
@@ -192,7 +192,7 @@ describe("TRPC calls associated with in GameData", async () => {
     expect(isValidResult(result, validationSchema)).toEqual(true);
   });
 
-  it("lastest snapshot returned", async () => {
+  it("latest snapshot returned", async () => {
     const caller = appRouter.createCaller(userWithAuth);
     await caller.saveGameData({ ...TRAINING_DATA, score: 0 });
     await caller.saveGameData({ ...TRAINING_DATA, score: 0 });


### PR DESCRIPTION
fixes #77 

Simple solution here is to open a new tab for users wanting to study their misidentified mushrooms, therefore enabling users to preserve end of game state in their main tab while studying mushrooms in new tabs.

Preserving game state between routes in Next is possible (e.g. with query params) but adds complexity given the way trpc/react query refetches data and may not be necessary here? @OliverWales
 What do you think?